### PR TITLE
fix reload bug

### DIFF
--- a/client/components/PostComponent/PostComponent.tsx
+++ b/client/components/PostComponent/PostComponent.tsx
@@ -43,7 +43,14 @@ export default function PostComponent() {
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    addPostMutation.mutate({ post: form, image })
+    addPostMutation.mutate(
+      { post: form, image },
+      {
+        onSuccess: () => {
+          window.location.reload()
+        },
+      },
+    )
     setForm('')
     setImage('')
   }


### PR DESCRIPTION
I've fixed the problem with posting. Now, when we post a text and image URL, the page automatically reloads. No more sneaky pressing F5!